### PR TITLE
Re-create assets folder README to point to new location.

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,5 @@
+# Google Cloud Applied AI Engineering
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
+The content you are looking for is probably somewhere [here](../genai-on-vertex-ai).


### PR DESCRIPTION
The cleanup of the repo removed the assets subfolder, where content was originally located. Recreating the assets README.md points to the new location for that content in the genai-on-vertex-ai subfolder.