### PR TITLE
fix: remove model garden reference from code interpreter notebook.

### DIFF
--- a/genai-on-vertex-ai/vertex_ai_extensions/notebooks/data_science_code_interpreter.ipynb
+++ b/genai-on-vertex-ai/vertex_ai_extensions/notebooks/data_science_code_interpreter.ipynb
@@ -127,7 +127,7 @@
    "source": [
     "## Vertex AI Extensions Code Interpreter Extension\n",
     "\n",
-    "The [Code Interpreter](https://cloud.google.com/vertex-ai/generative-ai/docs/extensions/google-extensions.md#code_interpreter_extension) extension provides access to a Python interpreter with a sandboxed, secure execution environment that can be used with any model in the Vertex AI Model Garden. This extension can generate and execute code in response to a user query or workflow. It allows the user or LLM agent to perform various tasks such as data analysis and visualization on new or existing data files.\n",
+    "The [Code Interpreter](https://cloud.google.com/vertex-ai/generative-ai/docs/extensions/google-extensions.md#code_interpreter_extension) extension provides access to a Python interpreter with a sandboxed, secure execution environment. This extension can generate and execute code in response to a user query or workflow. It allows the user or LLM agent to perform various tasks such as data analysis and visualization on new or existing data files.\n",
     "\n",
     "You can use the Code Interpreter extension to:\n",
     "\n",


### PR DESCRIPTION
Remove accidental model garden reference in Vertex Code Interpreter notebook. This is not a feature in the product.